### PR TITLE
Use runtime function to see if receiver is a class or instance

### DIFF
--- a/URLMock.xcworkspace/xcshareddata/URLMock.xccheckout
+++ b/URLMock.xcworkspace/xcshareddata/URLMock.xccheckout
@@ -10,29 +10,29 @@
 	<string>URLMock</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>BC7EE9B8-721A-4512-A42D-F7CF98F8802B</key>
+		<key>01029C1E3BA761B933CEB9CE7B047305E9201014</key>
 		<string>ssh://github.com/twotoasters/URLMock.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>URLMock.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>BC7EE9B8-721A-4512-A42D-F7CF98F8802B</key>
+		<key>01029C1E3BA761B933CEB9CE7B047305E9201014</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
 	<string>ssh://github.com/twotoasters/URLMock.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>BC7EE9B8-721A-4512-A42D-F7CF98F8802B</string>
+	<string>01029C1E3BA761B933CEB9CE7B047305E9201014</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>BC7EE9B8-721A-4512-A42D-F7CF98F8802B</string>
+			<string>01029C1E3BA761B933CEB9CE7B047305E9201014</string>
 			<key>IDESourceControlWCCName</key>
 			<string>URLMock</string>
 		</dict>

--- a/URLMock/Utilities/UMKErrorUtilities.m
+++ b/URLMock/Utilities/UMKErrorUtilities.m
@@ -26,7 +26,7 @@
 
 #import <URLMock/UMKErrorUtilities.h>
 
-#import <ObjC/ObjC-Runtime.h>
+#import <objc/runtime.h>
 
 
 NSString *UMKPrettySelector(id receiver, SEL selector)


### PR DESCRIPTION
Some time in the ten years since I originally wrote these functions, the Objective-C runtime exposed a function that tests to see if a class is a metaclass or not. This seems like a much better check than the one I was using.
