### PR TITLE
Fix range exception on empty query string

### DIFF
--- a/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
+++ b/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
@@ -95,5 +95,21 @@
     XCTAssertEqualObjects([UMKMockURLProtocol expectedMockRequests], @[], @"Mock request not removed");
 }
 
+- (void)testCanonicalURL
+{
+    NSURL *testURL1 = [NSURL URLWithString:@"http://domain.com"];
+    NSURL *canonicalURL1 = [UMKMockURLProtocol canonicalURLForURL:testURL1];
+    XCTAssertEqualObjects(testURL1, canonicalURL1, @"canonicalURL should not mutate a URL without a query string");
+    
+    NSURL *testURL2 = [NSURL URLWithString:@"http://domain.com?"];
+    NSURL *canonicalURL2 = [UMKMockURLProtocol canonicalURLForURL:testURL2];
+    XCTAssertEqualObjects(testURL2, canonicalURL2, @"canonicalURL should not mutate a URL with an empty query string");
+    
+    NSURL *testURL3 = [NSURL URLWithString:@"http://domain?a=foo&b=bar&c=baz"];
+    NSURL *canonicalURL3 = [UMKMockURLProtocol canonicalURLForURL:testURL3];
+    NSURL *testURL4 = [NSURL URLWithString:@"http://domain?b=bar&c=baz&a=foo"];
+    NSURL *canonicalURL4 = [UMKMockURLProtocol canonicalURLForURL:testURL4];
+    XCTAssertEqualObjects(canonicalURL3, canonicalURL4, @"canonical URLs should be equal regardless of parameter order");
+}
 
 @end

--- a/URLMock/Mock URL Protocol/UMKMockURLProtocol.m
+++ b/URLMock/Mock URL Protocol/UMKMockURLProtocol.m
@@ -481,7 +481,7 @@ NSString *const kUMKUnservicedMockRequestsKey = @"UMKUnservicedMockRequests";
     NSString *query = canonicalURL.query;
 
     // If there's a query, make sure the order of the parameters is consistent
-    if (query) {
+    if (query.length > 0) {
         NSString *canonicalQueryString = [[NSDictionary umk_dictionaryWithURLEncodedParameterString:query] umk_URLEncodedParameterString];
         NSString *URLString = [canonicalURL absoluteString];
         canonicalURL = [NSURL URLWithString:[URLString stringByReplacingCharactersInRange:[URLString rangeOfString:query]


### PR DESCRIPTION
When a URL with a empty query string (ex: http://domain.com?) was passed to `canonicalURL:` a range exception was thrown due to `rangeOfString:` returning `{NSNotFound, 0}` and then being passed into `stringByReplacingCharactersInRange:withString:`
