### PR TITLE
Update APIs in UMKURLEncodedParameterStringParser

### DIFF
--- a/Tests/Unit Tests/Utilities/UMKURLEncodedParameterStringParserTests.m
+++ b/Tests/Unit Tests/Utilities/UMKURLEncodedParameterStringParserTests.m
@@ -42,13 +42,11 @@
 - (void)testInit
 {
     NSString *string = UMKRandomUnicodeString();
-    NSStringEncoding encoding = random() % 16 + 1;
-    
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:encoding];
+
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     
     XCTAssertNotNil(parser, @"Returns nil");
     XCTAssertEqualObjects(parser.string, string, @"String is not set correctly");
-    XCTAssertEqual(parser.encoding, encoding, @"Encoding is not set correctly");
 }
 
 
@@ -61,7 +59,7 @@
         NSDictionary *dictionary = UMKRandomURLEncodedParameterDictionary(maxNestingDepth, maxElementCountPerCollection);
         NSString *string = [dictionary umk_URLEncodedParameterString];
         
-        UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+        UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
         NSDictionary *parsedDictionary = [parser parse];
         XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     }
@@ -82,7 +80,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -95,7 +93,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z][]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -108,7 +106,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z][]=10&x[y][z][]=5";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -121,7 +119,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][z]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -134,7 +132,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][w]=10&x[y][][z]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -147,7 +145,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][v][w]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -160,7 +158,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][v][w]=10&x[y][][z]=10";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -173,7 +171,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][z]=10&x[y][][z]=20";
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -186,7 +184,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][w]=a&x[y][][z]=10&x[y][][w]=b&x[y][][z]=20";
     
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -199,7 +197,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz=&foo=bar";
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -212,7 +210,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz[]=1&baz[]=2&baz[]=3&foo=bar";
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -225,7 +223,7 @@
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz[]=1&baz[]=2&baz[]=3&foo[]=bar";
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
@@ -237,7 +235,7 @@
     NSString *string = @"x=a&x=b";
     NSDictionary *dictionary = @{ @"x" : @"b" };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -248,7 +246,7 @@
     NSString *string = @"x[y]=a&x[y]=b";
     NSDictionary *dictionary = @{ @"x" : @{ @"y" : @"b" } };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -259,7 +257,7 @@
     NSString *string = @"a[b[][c]]=d";
     NSDictionary *dictionary = @{ @"a" : @{ @"b" : @[ @{ @"c" : @"d" } ] } };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -270,7 +268,7 @@
     NSString *string = @"x[]=a&x[]=b";
     NSDictionary *dictionary = @{ @"x" : @[ @"a", @"b" ] };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -281,7 +279,7 @@
     NSString *string = @"a][b=c";
     NSDictionary *dictionary = @{ @"a" : @{ @"b" : @"c" } };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -292,7 +290,7 @@
     NSString *string = @"a]=b";
     NSDictionary *dictionary = @{ @"a" : @"b" };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -303,7 +301,7 @@
     NSString *string = @"a[=b";
     NSDictionary *dictionary = @{ @"a" : @{} };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -314,7 +312,7 @@
     NSString *string = @"a]c[=b";
     NSDictionary *dictionary = @{ @"a" : @{ @"c" : @{} } };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
@@ -325,7 +323,7 @@
     NSString *string = @"a_./[*)@(ಠ_ಠ=b";
     NSDictionary *dictionary = @{ @"a_./" : @{ @"*)@(ಠ_ಠ" : @"b" } };
 
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:NSUTF8StringEncoding];
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
     NSDictionary *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }

--- a/URLMock/Categories/NSDictionary+UMKURLEncoding.h
+++ b/URLMock/Categories/NSDictionary+UMKURLEncoding.h
@@ -57,12 +57,12 @@
 + (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string;
 
 /*!
- @abstract Returns a new dictionary by parsing the specified URL encoded parameter string with the specified encoding.
+ @abstract Deprecated. Use +umk_dictionaryWithURLEncodedParameterString instead.
  @param string The URL encoded parameter string to parse.
- @param encoding The string encoding to use when unescaping the parameter string's percent sequences.
+ @param encoding Ignored.
  @result A new dictionary containing the objects specified in the URL encoded parameter string.
  */
-+ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding;
++ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
 
 /*!
  @abstract Returns whether the receiver is a valid URL encoded parameter dictionary.

--- a/URLMock/Categories/NSDictionary+UMKURLEncoding.m
+++ b/URLMock/Categories/NSDictionary+UMKURLEncoding.m
@@ -113,15 +113,15 @@
 
 + (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string
 {
-    return [self umk_dictionaryWithURLEncodedParameterString:string encoding:NSUTF8StringEncoding];
+    NSParameterAssert(string);
+    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
+    return [parser parse];
 }
 
 
 + (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding
 {
-    NSParameterAssert(string);
-    UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string encoding:encoding];
-    return [parser parse];
+    return [self umk_dictionaryWithURLEncodedParameterString:string];
 }
 
 

--- a/URLMock/Utilities/UMKURLEncodedParameterStringParser.h
+++ b/URLMock/Utilities/UMKURLEncodedParameterStringParser.h
@@ -45,17 +45,26 @@
 /*! The string the instance parses. */
 @property (nonatomic, copy, readonly) NSString *string;
 
-/*! The encoding that the instance's percent-escape sequences were encoded in. */
-@property (nonatomic, assign, readonly) NSStringEncoding encoding;
+/*!
+ Deprecated. UTF-8 is always used during parsing.
+ */
+@property (nonatomic, assign, readonly) NSStringEncoding encoding DEPRECATED_ATTRIBUTE;
 
 
 /*!
- @abstract Initializes a new UMKURLEncodedParameterStringParser instance with the specified string and encoding.
+ @abstract Initializes a new UMKURLEncodedParameterStringParser instance with the specified string.
  @param string The URL encoded parameter string to parse.
- @param encoding The encoding that the string used for percent-escape sequences.
  @result A newly initialized UMKURLEncodedParameterStringParser.
  */
-- (instancetype)initWithString:(NSString *)string encoding:(NSStringEncoding)encoding;
+- (instancetype)initWithString:(NSString *)string;
+
+/*!
+ @abstract Deprecated. Use -initWithString: instead.
+ @param string The URL encoded parameter string to parse.
+ @param encoding Ignored.
+ @result A newly initialized UMKURLEncodedParameterStringParser.
+ */
+- (instancetype)initWithString:(NSString *)string encoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
 
 /*!
  @abstract Parses the receiver's string and returns a dictionary of the resulting object.

--- a/URLMock/Utilities/UMKURLEncodedParameterStringParser.m
+++ b/URLMock/Utilities/UMKURLEncodedParameterStringParser.m
@@ -35,21 +35,32 @@
 
 - (instancetype)init
 {
-    return [self initWithString:nil encoding:NSUTF8StringEncoding];
+    return [self initWithString:nil];
+}
+
+
+- (instancetype)initWithString:(NSString *)string
+{
+    NSParameterAssert(string);
+
+    self = [super init];
+    if (self) {
+        _string = [string copy];
+    }
+
+    return self;
 }
 
 
 - (instancetype)initWithString:(NSString *)string encoding:(NSStringEncoding)encoding
 {
-    NSParameterAssert(string);
-    
-    self = [super init];
-    if (self) {
-        _string = [string copy];
-        _encoding = encoding;
-    }
-    
-    return self;
+    return [self initWithString:string];
+}
+
+
+- (NSStringEncoding)encoding
+{
+    return NSUTF8StringEncoding;
 }
 
 
@@ -80,8 +91,8 @@
     
     for (NSString *keyValueString in keyValueStrings) {
         NSArray *keyValuePair = [keyValueString componentsSeparatedByString:@"="];
-        id key = [keyValuePair[0] stringByReplacingPercentEscapesUsingEncoding:self.encoding];
-        id value = (keyValuePair.count > 1) ? [keyValuePair[1] stringByReplacingPercentEscapesUsingEncoding:self.encoding] : [NSNull null];
+        id key = [keyValuePair[0] stringByRemovingPercentEncoding];
+        id value = (keyValuePair.count > 1) ? [keyValuePair[1] stringByRemovingPercentEncoding] : [NSNull null];
         [pairs addObject:[[UMKParameterPair alloc] initWithKey:key value:value]];
     }
 


### PR DESCRIPTION
`-stringByReplacingPercentEscapesUsingEncoding:` is deprecated in iOS 9.
The change to replace it cascaded into `NSDictionary+UMKURLEncoding` and
the tests as well.

@prachigauriar please review.