### PR TITLE
Do not assume UMKParameterPair values are strings

### DIFF
--- a/Tests/Unit Tests/Utilities/UMKParameterPairTests.m
+++ b/Tests/Unit Tests/Utilities/UMKParameterPairTests.m
@@ -64,4 +64,14 @@
     value = nil;
 }
 
+- (void)testURLEncodingNonStringValues
+{
+    NSString *key = UMKRandomUnicodeString();
+    id value = @1;
+
+    UMKParameterPair *pair = [[UMKParameterPair alloc] initWithKey:key value:value];
+
+    XCTAssertNoThrow([pair URLEncodedStringValue], @"-URLEncodedStringValue should not throw");
+}
+
 @end

--- a/URLMock.podspec
+++ b/URLMock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "URLMock"
-  s.version      = "1.3.0"
+  s.version      = "1.3.1"
 
   s.summary      = "A Cocoa framework for mocking and stubbing URL requests and responses."
   s.description  = <<-DESC

--- a/URLMock/Utilities/UMKParameterPair.m
+++ b/URLMock/Utilities/UMKParameterPair.m
@@ -57,7 +57,7 @@
 
     NSString *stringValue = [self URLEncodedString:self.key allowedCharacters:kUMKKeyAllowedCharacters];
     if (self.value && self.value != [NSNull null]) {
-        stringValue = [stringValue stringByAppendingFormat:@"=%@", [self URLEncodedString:self.value allowedCharacters:kUMKValueAllowedCharacters]];
+        stringValue = [stringValue stringByAppendingFormat:@"=%@", [self URLEncodedString:[self.value description] allowedCharacters:kUMKValueAllowedCharacters]];
     }
     
     return stringValue;


### PR DESCRIPTION
@prachigauriar please review. Pre-1.3.0 versions of URLMock allowed `UMKParameterPair` values to be non-string objects by using `-description`. This change restores that behavior and adds a regression test.