### PR TITLE
Swift-ify Objective-C interfaces

### DIFF
--- a/Tests/Integration Tests/UMKIntegrationTestCase.m
+++ b/Tests/Integration Tests/UMKIntegrationTestCase.m
@@ -70,7 +70,7 @@
 {
     id verifier = [UMKMessageCountingProxy messageCountingProxyWithObject:[[UMKURLConnectionVerifier alloc] init]];
     NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request delegate:verifier startImmediately:NO];
-    connection.delegateQueue = [[self class] networkOperationQueue];
+    connection.delegateQueue = [self.class networkOperationQueue];
     [connection start];
     return verifier;
 }
@@ -83,7 +83,7 @@
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.protocolClasses = @[ [UMKMockURLProtocol class] ];
 
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:verifier delegateQueue:[[self class] networkOperationQueue]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:verifier delegateQueue:[self.class networkOperationQueue]];
 
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request];
     [task resume];

--- a/Tests/Integration Tests/URLMockIntegrationTests.m
+++ b/Tests/Integration Tests/URLMockIntegrationTests.m
@@ -344,11 +344,11 @@
     XCTAssertFalse([UMKMockURLProtocol verifyWithError:&error], @"Returned YES despite unexpected request");
     XCTAssertEqual([error code], kUMKUnexpectedRequestErrorCode, @"Incorrect error code");
 
-    NSArray *unexpectedRequests = [[error userInfo] objectForKey:kUMKUnexpectedRequestsKey];
+    NSArray<NSURLRequest *> *unexpectedRequests = error.userInfo[kUMKUnexpectedRequestsKey];
     XCTAssertNotNil(unexpectedRequests, @"Unexpected requests not included in error userInfo dictionary");
     XCTAssertEqual(unexpectedRequests.count, (NSUInteger)1, @"Unexpected requests contains wrong number of requests");
     
-    NSURLRequest *unexpectedRequest = [unexpectedRequests firstObject];
+    NSURLRequest *unexpectedRequest = unexpectedRequests.firstObject;
     NSURL *canonicalRequestURL = [UMKMockURLProtocol canonicalURLForURL:request.URL];
     NSURL *canonicalUnexpectedRequestURL = [UMKMockURLProtocol canonicalURLForURL:unexpectedRequest.URL];
 
@@ -365,7 +365,7 @@
     [UMKMockURLProtocol setVerificationEnabled:YES];
 
     UMKPatternMatchingMockRequest *mockRequest = [[UMKPatternMatchingMockRequest alloc] initWithURLPattern:@"https://domain.com/subdomain/:resource"];
-    mockRequest.responderGenerationBlock = ^id<UMKMockURLResponder>(NSURLRequest *request, NSDictionary *parameters) {
+    mockRequest.responderGenerationBlock = ^id<UMKMockURLResponder>(NSURLRequest *request, NSDictionary<NSString *, NSString *> *parameters) {
         return [UMKMockHTTPResponder mockHTTPResponderWithStatusCode:random() % 500];
     };
 
@@ -389,7 +389,7 @@
     NSData *body = [UMKRandomUnicodeString() dataUsingEncoding:NSUTF8StringEncoding];
 
     UMKPatternMatchingMockRequest *mockRequest = [[UMKPatternMatchingMockRequest alloc] initWithURLPattern:pattern];
-    mockRequest.responderGenerationBlock = ^id<UMKMockURLResponder>(NSURLRequest *request, NSDictionary *parameters) {
+    mockRequest.responderGenerationBlock = ^id<UMKMockURLResponder>(NSURLRequest *request, NSDictionary<NSString *, NSString *> *parameters) {
         UMKMockHTTPResponder *responder = [UMKMockHTTPResponder mockHTTPResponderWithStatusCode:random() % 500];
         responder.body = [request umk_HTTPBodyData];
         return responder;

--- a/Tests/Unit Tests/Categories/NSURLRequestUMKHTTPConvenienceTests.m
+++ b/Tests/Unit Tests/Categories/NSURLRequestUMKHTTPConvenienceTests.m
@@ -74,7 +74,7 @@
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:UMKRandomHTTPURL()];
     XCTAssertNil([request umk_parametersFromURLEncodedHTTPBody], @"Does not return nil when body is nil");
 
-    NSDictionary *parameters = UMKRandomDictionaryOfStringsWithElementCount(10);
+    NSDictionary<NSString *, NSString *> *parameters = UMKRandomDictionaryOfStringsWithElementCount(10);
     request.HTTPBody = [[parameters umk_URLEncodedParameterString] dataUsingEncoding:NSUTF8StringEncoding];
     XCTAssertEqualObjects([request umk_parametersFromURLEncodedHTTPBody], parameters, @"Returns incorrect parameters");
 
@@ -103,9 +103,11 @@
 - (void)testHTTPHeadersAreEqualToHeaders
 {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-    XCTAssertTrue([request umk_HTTPHeadersAreEqualToHeaders:nil], @"Headers are not equal");
 
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
+    id nilObject = nil;
+    XCTAssertTrue([request umk_HTTPHeadersAreEqualToHeaders:nilObject], @"Headers are not equal");
+
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
     [request setAllHTTPHeaderFields:headers];
 
     NSUInteger i = 0;
@@ -130,7 +132,7 @@
 
     [request setValue:nil forHTTPHeaderField:[request.allHTTPHeaderFields.keyEnumerator nextObject]];
     XCTAssertFalse([request umk_HTTPHeadersAreEqualToHeaders:headers], @"Headers are equal when they shouldn't be");
-    XCTAssertFalse([request umk_HTTPHeadersAreEqualToHeaders:nil], @"Headers are equal when they shouldn't be");
+    XCTAssertFalse([request umk_HTTPHeadersAreEqualToHeaders:nilObject], @"Headers are equal when they shouldn't be");
 }
 
 @end

--- a/Tests/Unit Tests/Mock Messages/UMKMockHTTPMessageTests.m
+++ b/Tests/Unit Tests/Mock Messages/UMKMockHTTPMessageTests.m
@@ -67,12 +67,13 @@
 - (void)testHeadersAccessors
 {
     // Getting and setting headers as a dictionary
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
     self.message.headers = headers;
     XCTAssertEqualObjects(self.message.headers, headers, @"Headers not set correctly");
 
     // Getting nil and unset headers
-    XCTAssertNil([self.message valueForHeaderField:nil], @"Non-nil header value for nil field");
+    id nilObject = nil;
+    XCTAssertNil([self.message valueForHeaderField:nilObject], @"Non-nil header value for nil field");
     XCTAssertNil([self.message valueForHeaderField:UMKRandomAlphanumericString()], @"Non-nil header value for unset field");
 
     // Case-insensitivity for getting header values
@@ -85,9 +86,9 @@
 
     
     // Setting nil keys or values
-    XCTAssertThrowsSpecificNamed([self.message setValue:nil forHeaderField:UMKRandomAlphanumericString()], NSException,
+    XCTAssertThrowsSpecificNamed([self.message setValue:nilObject forHeaderField:UMKRandomAlphanumericString()], NSException,
                                  NSInvalidArgumentException, @"Does not throw when given nil value");
-    XCTAssertThrowsSpecificNamed([self.message setValue:UMKRandomAlphanumericString() forHeaderField:nil], NSException,
+    XCTAssertThrowsSpecificNamed([self.message setValue:UMKRandomAlphanumericString() forHeaderField:nilObject], NSException,
                                  NSInvalidArgumentException, @"Does not throw when given nil field");
 
     // Case-insensitivity for setting field values
@@ -109,7 +110,7 @@
         XCTAssertEqualObjects([self.message valueForHeaderField:field], randomValue, @"Incorrect header value set for capitalized field");
     }];
 
-    NSDictionary *before = self.message.headers;
+    NSDictionary<NSString *, NSString *> *before = self.message.headers;
     [self.message removeValueForHeaderField:UMKRandomAlphanumericString()];
     XCTAssertEqualObjects(self.message.headers, before, @"Removal of unset key changed headers");
 
@@ -141,7 +142,7 @@
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     XCTAssertTrue([self.message headersAreEqualToHeadersOfRequest:request], @"Headers are not equal");
     
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
     self.message.headers = headers;
 
     NSUInteger i = 0;
@@ -164,13 +165,13 @@
 
     XCTAssertTrue([self.message headersAreEqualToHeadersOfRequest:request], @"Headers are not equal");
     XCTAssertFalse([self.message headersAreEqualToHeadersOfRequest:[[NSURLRequest alloc] init]], @"Headers are equal when they should not be.");
-    XCTAssertFalse([self.message headersAreEqualToHeadersOfRequest:nil], @"Headers are equal to those of a nil request.");
+
 
     [self.message removeValueForHeaderField:[self.message.headers.keyEnumerator nextObject]];
     XCTAssertFalse([self.message headersAreEqualToHeadersOfRequest:request], @"Headers are equal when they shouldn't be");
 
     self.message.headers = nil;
-    XCTAssertFalse([self.message headersAreEqualToHeadersOfRequest:nil], @"Headers are equal to those of a nil request");
+    XCTAssertFalse([self.message headersAreEqualToHeadersOfRequest:request], @"Headers are equal when they shouldn't be");
 }
 
 
@@ -220,11 +221,11 @@
     NSString *contentType = UMKRandomAlphanumericStringWithLength(8);
     [self.message setValue:contentType forHeaderField:kUMKMockHTTPMessageContentTypeHeaderField];
 
-    NSDictionary *parameters = UMKRandomDictionaryOfStringsWithElementCount(10);
+    NSDictionary<NSString *, NSString *> *parameters = UMKRandomDictionaryOfStringsWithElementCount(10);
     [self.message setBodyByURLEncodingParameters:parameters];
 
     NSString *bodyString = [[NSString alloc] initWithData:self.message.body encoding:NSUTF8StringEncoding];
-    NSDictionary *manuallyDecodedBody = [NSDictionary umk_dictionaryWithURLEncodedParameterString:bodyString];
+    NSDictionary<NSString *, id> *manuallyDecodedBody = [NSDictionary umk_dictionaryWithURLEncodedParameterString:bodyString];
     XCTAssertEqualObjects([self.message parametersFromURLEncodedBody], parameters, @"Did not set body correctly");
     XCTAssertEqualObjects([self.message parametersFromURLEncodedBody], manuallyDecodedBody, @"Did not set body correctly");
     XCTAssertEqualObjects([self.message valueForHeaderField:kUMKMockHTTPMessageContentTypeHeaderField], contentType, @"Content-Type header value was overwritten");
@@ -239,7 +240,7 @@
 
 - (void)testStringBodyAccessors
 {
-    NSDictionary *beforeHeaders = self.message.headers;
+    NSDictionary<NSString *, NSString *> *beforeHeaders = self.message.headers;
     NSString *bodyString = UMKRandomUnicodeString();
     [self.message setBodyWithString:bodyString];
     XCTAssertEqualObjects(self.message.body, [bodyString dataUsingEncoding:NSUTF8StringEncoding], @"Body string was not set correctly");

--- a/Tests/Unit Tests/Mock Messages/UMKMockHTTPRequestTests.m
+++ b/Tests/Unit Tests/Mock Messages/UMKMockHTTPRequestTests.m
@@ -99,7 +99,7 @@
 {
     XCTAssertNil([UMKMockHTTPRequest defaultHeaders], @"Not initially nil");
     
-    NSDictionary *defaultHeaders = UMKRandomDictionaryOfStringsWithElementCount(random() % 10 + 1);
+    NSDictionary<NSString *, NSString *> *defaultHeaders = UMKRandomDictionaryOfStringsWithElementCount(random() % 10 + 1);
     [UMKMockHTTPRequest setDefaultHeaders:defaultHeaders];
     XCTAssertEqualObjects([UMKMockHTTPRequest defaultHeaders], defaultHeaders, @"Not set correctly");
 
@@ -119,7 +119,7 @@
     NSURL *URL = UMKRandomHTTPURL();
 
     UMKMockHTTPRequest *mockRequest = [UMKMockHTTPRequest mockHTTPPostRequestWithURL:URL];
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(12);
     mockRequest.headers = headers;
 
     NSString *bodyString = UMKRandomUnicodeStringWithLength(1024);
@@ -154,7 +154,7 @@
     request.HTTPBody = [NSJSONSerialization dataWithJSONObject:JSONObject options:0 error:NULL];
     XCTAssertTrue([mockRequest matchesURLRequest:request], @"Does not match equivalent request.");
     
-    NSDictionary *parameters = UMKRandomDictionaryOfStringsWithElementCount(4);
+    NSDictionary<NSString *, NSString *> *parameters = UMKRandomDictionaryOfStringsWithElementCount(4);
     [mockRequest setBodyByURLEncodingParameters:parameters];
     [mockRequest setValue:kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeaderValue forHeaderField:kUMKMockHTTPMessageContentTypeHeaderField];
     XCTAssertFalse([mockRequest matchesURLRequest:request], @"Matches request with incorrect headers and body.");
@@ -174,7 +174,9 @@
     mockRequest.responder = responder;
     
     XCTAssertEqualObjects(responder, mockRequest.responder, @"Responder is not set correctly.");
-    XCTAssertEqualObjects(responder, [mockRequest responderForURLRequest:nil], @"Incorrect responder returned");
+
+    NSURLRequest *arbitraryRequest = [[NSURLRequest alloc] initWithURL:UMKRandomHTTPURL()];
+    XCTAssertEqualObjects(responder, [mockRequest responderForURLRequest:arbitraryRequest], @"Incorrect responder returned");
 
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:URL];
     XCTAssertEqualObjects(responder, [mockRequest responderForURLRequest:request], @"Incorrect responder returned");

--- a/Tests/Unit Tests/Mock Messages/UMKMockHTTPResponderTests.m
+++ b/Tests/Unit Tests/Mock Messages/UMKMockHTTPResponderTests.m
@@ -105,7 +105,7 @@
 - (void)testMockHTTPResponderWithStatusCodeHeaders
 {
     NSUInteger statusCode = random() % 500 + 100;
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
 
     UMKMockHTTPResponder *responder = [UMKMockHTTPResponder mockHTTPResponderWithStatusCode:statusCode headers:headers];
 
@@ -150,7 +150,7 @@
 - (void)testMockHTTPResponderWithStatusCodeHeadersBody
 {
     NSUInteger statusCode = random() % 500 + 100;
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
     NSData *body = [UMKRandomUnicodeStringWithLength(1024) dataUsingEncoding:NSUTF8StringEncoding];
 
     UMKMockHTTPResponder *responder = [UMKMockHTTPResponder mockHTTPResponderWithStatusCode:statusCode headers:headers body:body];
@@ -174,7 +174,7 @@
 - (void)testMockHTTPResponderWithStatusCodeHeadersBodyChunkCountHintDelayBetweenChunks
 {
     NSUInteger statusCode = random() % 500 + 100;
-    NSDictionary *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
+    NSDictionary<NSString *, NSString *> *headers = UMKRandomDictionaryOfStringsWithElementCount(10);
     NSData *body = [UMKRandomUnicodeStringWithLength(1024) dataUsingEncoding:NSUTF8StringEncoding];
 
     UMKMockHTTPResponder *responder = [UMKMockHTTPResponder mockHTTPResponderWithStatusCode:statusCode headers:headers body:body];

--- a/Tests/Unit Tests/Utilities/UMKTestUtilitiesTests.m
+++ b/Tests/Unit Tests/Utilities/UMKTestUtilitiesTests.m
@@ -100,7 +100,7 @@
 
 - (void)testRandomAlphanumericString
 {
-    NSCharacterSet *invertedAlphanumerics = [[self class] invertedAlphanumericCharacterSet];
+    NSCharacterSet *invertedAlphanumerics = [self.class invertedAlphanumericCharacterSet];
     
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSString *randomString = UMKRandomAlphanumericString();
@@ -116,7 +116,7 @@
 
 - (void)testRandomAlphanumericStringWithLength
 {
-    NSCharacterSet *invertedAlphanumerics = [[self class] invertedAlphanumericCharacterSet];
+    NSCharacterSet *invertedAlphanumerics = [self.class invertedAlphanumericCharacterSet];
 
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSUInteger length = random() % 1024 + 1;
@@ -133,7 +133,7 @@
 
 - (void)testRandomUnicodeString
 {
-    NSCharacterSet *invertedRandomUnicodeCharacters = [[self class] invertedRandomUnicodeCharacterSet];
+    NSCharacterSet *invertedRandomUnicodeCharacters = [self.class invertedRandomUnicodeCharacterSet];
     
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSString *randomString = UMKRandomUnicodeString();
@@ -149,7 +149,7 @@
 
 - (void)testRandomUnicodeStringWithLength
 {
-    NSCharacterSet *invertedRandomUnicodeCharacters = [[self class] invertedRandomUnicodeCharacterSet];
+    NSCharacterSet *invertedRandomUnicodeCharacters = [self.class invertedRandomUnicodeCharacterSet];
     
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSUInteger length = random() % 1024 + 1;
@@ -166,7 +166,7 @@
 
 - (void)testRandomIdentifierString
 {
-    NSRegularExpression *identifierRegularExpression = [[self class] identifierRegularExpression];
+    NSRegularExpression *identifierRegularExpression = [self.class identifierRegularExpression];
 
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSString *randomString = UMKRandomIdentifierString();
@@ -184,7 +184,7 @@
 
 - (void)testRandomIdentifierStringWithLength
 {
-    NSRegularExpression *identifierRegularExpression = [[self class] identifierRegularExpression];
+    NSRegularExpression *identifierRegularExpression = [self.class identifierRegularExpression];
 
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSUInteger length = random() % 1024 + 1;
@@ -247,7 +247,7 @@
 - (void)testRandomDictionaryOfStringsWithElementCount
 {
     NSUInteger elementCount = random() % 100 + 1;
-    NSDictionary *dictionary = UMKRandomDictionaryOfStringsWithElementCount(elementCount);
+    NSDictionary<NSString *, NSString *> *dictionary = UMKRandomDictionaryOfStringsWithElementCount(elementCount);
     
     XCTAssertEqual(dictionary.count, elementCount, @"Returned dictionary's element count is incorrect");
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
@@ -324,8 +324,8 @@
 
 - (void)testRandomHTTPURL
 {
-    NSMutableSet *URLs = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
-    NSMutableSet *hosts = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
+    NSMutableSet<NSURL *> *URLs = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
+    NSMutableSet<NSString *> *hosts = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
     
     NSUInteger fragmentCount = 0;
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
@@ -338,7 +338,7 @@
         XCTAssertTrue(URL.pathComponents.count >= 2 && URL.pathComponents.count <= 11, @"Incorrect number of path components");
 
         if (URL.query.length > 0) {
-            NSDictionary *parameters = [NSDictionary umk_dictionaryWithURLEncodedParameterString:URL.query];
+            NSDictionary<NSString *, id> *parameters = [NSDictionary umk_dictionaryWithURLEncodedParameterString:URL.query];
             XCTAssertNotNil(parameters, @"parameters from query is nil");
             XCTAssertTrue([parameters umk_isValidURLEncodedParameterDictionary], @"parameters is not a valid URL encoded parameter dictionary");
             
@@ -364,8 +364,8 @@
 
 - (void)testRandomHTTPMethod
 {
-    NSSet *methods = [NSSet setWithObjects:@"DELETE", @"GET", @"HEAD", @"PATCH", @"POST", @"PUT", nil];
-    NSMutableSet *returnedValues = [NSMutableSet setWithCapacity:methods.count];
+    NSSet<NSString *> *methods = [NSSet setWithObjects:@"DELETE", @"GET", @"HEAD", @"PATCH", @"POST", @"PUT", nil];
+    NSMutableSet<NSString *> *returnedValues = [NSMutableSet setWithCapacity:methods.count];
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         [returnedValues addObject:UMKRandomHTTPMethod()];
     }
@@ -376,8 +376,8 @@
 
 - (void)testRandomError
 {
-    NSMutableSet *domains = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
-    NSMutableSet *codes = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
+    NSMutableSet<NSString *> *domains = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
+    NSMutableSet<NSNumber *> *codes = [[NSMutableSet alloc] initWithCapacity:UMKIterationCount];
 
     for (NSUInteger i = 0; i < UMKIterationCount; ++i) {
         NSError *error = UMKRandomError();

--- a/Tests/Unit Tests/Utilities/UMKURLEncodedParameterStringParserTests.m
+++ b/Tests/Unit Tests/Utilities/UMKURLEncodedParameterStringParserTests.m
@@ -56,11 +56,11 @@
         NSUInteger maxNestingDepth = random() % 3 + 1;
         NSUInteger maxElementCountPerCollection = random() % 3 + 1;
         
-        NSDictionary *dictionary = UMKRandomURLEncodedParameterDictionary(maxNestingDepth, maxElementCountPerCollection);
+        NSDictionary<NSString *, id> *dictionary = UMKRandomURLEncodedParameterDictionary(maxNestingDepth, maxElementCountPerCollection);
         NSString *string = [dictionary umk_URLEncodedParameterString];
         
         UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-        NSDictionary *parsedDictionary = [parser parse];
+        NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
         XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     }
 }
@@ -69,19 +69,19 @@
 - (void)testParseWithDoubleAmpersand
 {
     NSURL *doubleAmpersandURL = [NSURL URLWithString:@"https://hostname.com/a/b/c?d=e&c&f=g"];
-    NSDictionary *parsedDictionary = [NSDictionary umk_dictionaryWithURLEncodedParameterString:doubleAmpersandURL.query];
+    NSDictionary<NSString *, id> *parsedDictionary = [NSDictionary umk_dictionaryWithURLEncodedParameterString:doubleAmpersandURL.query];
     XCTAssertNotNil(parsedDictionary, @"parsed dictionary is nil");
 }
 
 
 - (void)testParse1
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @"10" } } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @"10" } } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -89,12 +89,12 @@
 
 - (void)testParse2
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @[ @"10" ] } } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @[ @"10" ] } } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z][]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -102,12 +102,12 @@
 
 - (void)testParse3
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @[ @"10", @"5" ] } } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @{ @"z" : @[ @"10", @"5" ] } } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][z][]=10&x[y][z][]=5";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -115,12 +115,12 @@
 
 - (void)testParse4
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10" } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10" } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][z]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -128,12 +128,12 @@
 
 - (void)testParse5
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"w" : @"10" } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"w" : @"10" } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][w]=10&x[y][][z]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -141,12 +141,12 @@
 
 - (void)testParse6
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"v" : @{ @"w" : @"10" } } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"v" : @{ @"w" : @"10" } } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][v][w]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -154,12 +154,12 @@
 
 - (void)testParse7
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"v" : @{ @"w" : @"10" } } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"v" : @{ @"w" : @"10" } } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][v][w]=10&x[y][][z]=10";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -167,12 +167,12 @@
 
 - (void)testParse8
 {
-    NSDictionary *dictionary = @{ @"x": @{ @"y" : @[ @{ @"z" : @"10" }, @{ @"z" : @"20" } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x": @{ @"y" : @[ @{ @"z" : @"10" }, @{ @"z" : @"20" } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][z]=10&x[y][][z]=20";
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -180,12 +180,12 @@
 
 - (void)testParse9
 {
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"w" : @"a" }, @{ @"z" : @"20", @"w" : @"b" } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @[ @{ @"z" : @"10", @"w" : @"a" }, @{ @"z" : @"20", @"w" : @"b" } ] } };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"x[y][][w]=a&x[y][][z]=10&x[y][][w]=b&x[y][][z]=20";
     
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -193,12 +193,12 @@
 
 - (void)testParse10
 {
-    NSDictionary *dictionary = @{ @"foo" : @"bar", @"baz" : @"" };
+    NSDictionary<NSString *, id> *dictionary = @{ @"foo" : @"bar", @"baz" : @"" };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz=&foo=bar";
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -206,12 +206,12 @@
 
 - (void)testParse11
 {
-    NSDictionary *dictionary = @{ @"foo" : @"bar", @"baz" : @[ @"1", @"2", @"3" ] };
+    NSDictionary<NSString *, id> *dictionary = @{ @"foo" : @"bar", @"baz" : @[ @"1", @"2", @"3" ] };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz[]=1&baz[]=2&baz[]=3&foo=bar";
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -219,12 +219,12 @@
 
 - (void)testParse12
 {
-    NSDictionary *dictionary = @{ @"foo" : @[ @"bar" ], @"baz" : @[ @"1", @"2", @"3" ] };
+    NSDictionary<NSString *, id> *dictionary = @{ @"foo" : @[ @"bar" ], @"baz" : @[ @"1", @"2", @"3" ] };
     NSString *generatedString = [dictionary umk_URLEncodedParameterString];
     NSString *string = @"baz[]=1&baz[]=2&baz[]=3&foo[]=bar";
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:generatedString];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
     XCTAssertEqualObjects(string, generatedString, @"Incorrect parameter string");
 }
@@ -233,10 +233,10 @@
 - (void)testParse13
 {
     NSString *string = @"x=a&x=b";
-    NSDictionary *dictionary = @{ @"x" : @"b" };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @"b" };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -244,10 +244,10 @@
 - (void)testParse14
 {
     NSString *string = @"x[y]=a&x[y]=b";
-    NSDictionary *dictionary = @{ @"x" : @{ @"y" : @"b" } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @{ @"y" : @"b" } };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -255,10 +255,10 @@
 - (void)testParse15
 {
     NSString *string = @"a[b[][c]]=d";
-    NSDictionary *dictionary = @{ @"a" : @{ @"b" : @[ @{ @"c" : @"d" } ] } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a" : @{ @"b" : @[ @{ @"c" : @"d" } ] } };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -266,10 +266,10 @@
 - (void)testParse16
 {
     NSString *string = @"x[]=a&x[]=b";
-    NSDictionary *dictionary = @{ @"x" : @[ @"a", @"b" ] };
+    NSDictionary<NSString *, id> *dictionary = @{ @"x" : @[ @"a", @"b" ] };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -277,10 +277,10 @@
 - (void)testParse17
 {
     NSString *string = @"a][b=c";
-    NSDictionary *dictionary = @{ @"a" : @{ @"b" : @"c" } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a" : @{ @"b" : @"c" } };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -288,10 +288,10 @@
 - (void)testParse18
 {
     NSString *string = @"a]=b";
-    NSDictionary *dictionary = @{ @"a" : @"b" };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a" : @"b" };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -299,10 +299,10 @@
 - (void)testParse19
 {
     NSString *string = @"a[=b";
-    NSDictionary *dictionary = @{ @"a" : @{} };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a" : @{} };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -310,10 +310,10 @@
 - (void)testParse20
 {
     NSString *string = @"a]c[=b";
-    NSDictionary *dictionary = @{ @"a" : @{ @"c" : @{} } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a" : @{ @"c" : @{} } };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 
@@ -321,10 +321,10 @@
 - (void)testParse21
 {
     NSString *string = @"a_./[*)@(ಠ_ಠ=b";
-    NSDictionary *dictionary = @{ @"a_./" : @{ @"*)@(ಠ_ಠ" : @"b" } };
+    NSDictionary<NSString *, id> *dictionary = @{ @"a_./" : @{ @"*)@(ಠ_ಠ" : @"b" } };
 
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
-    NSDictionary *parsedDictionary = [parser parse];
+    NSDictionary<NSString *, id> *parsedDictionary = [parser parse];
     XCTAssertEqualObjects(dictionary, parsedDictionary, @"Incorrect parse result");
 }
 

--- a/URLMock.xcodeproj/project.pbxproj
+++ b/URLMock.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = UMK;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Ticketmaster Entertainment, Inc.";
 				TargetAttributes = {

--- a/URLMock/Categories/NSDictionary+UMKURLEncoding.h
+++ b/URLMock/Categories/NSDictionary+UMKURLEncoding.h
@@ -28,6 +28,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  The UMKURLEncoding category of NSDictionary provides a methods for easily URL encoding and decoding dictionary
  objects.
@@ -54,7 +56,7 @@
  @param string The URL encoded parameter string to parse.
  @result A new dictionary containing the objects specified in the URL encoded parameter string.
  */
-+ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string;
++ (NSDictionary<NSString *, id> * _Nullable)umk_dictionaryWithURLEncodedParameterString:(NSString *)string;
 
 /*!
  @abstract Deprecated. Use +umk_dictionaryWithURLEncodedParameterString instead.
@@ -62,7 +64,7 @@
  @param encoding Ignored.
  @result A new dictionary containing the objects specified in the URL encoded parameter string.
  */
-+ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
++ (NSDictionary<NSString *, id> * _Nullable)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
 
 /*!
  @abstract Returns whether the receiver is a valid URL encoded parameter dictionary.
@@ -88,3 +90,5 @@
 - (NSString *)umk_URLEncodedParameterStringWithEncoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Categories/NSDictionary+UMKURLEncoding.m
+++ b/URLMock/Categories/NSDictionary+UMKURLEncoding.m
@@ -40,7 +40,7 @@
      values represent the values in the receiver.
  @result An array of parameter pairs.
  */
-- (NSArray *)umk_parameterPairsWithKey:(NSString *)key;
+- (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key;
 
 /*!
  @abstract Returns whether the object is a valid URL encoded parameter object.
@@ -59,7 +59,7 @@
 
 @implementation NSObject (UMKURLEncoding)
 
-- (NSArray *)umk_parameterPairsWithKey:(NSString *)key
+- (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key
 {
     return @[ [[UMKParameterPair alloc] initWithKey:key value:self] ];
 }
@@ -77,9 +77,9 @@
 
 @implementation NSArray (UMKURLEncoding)
 
-- (NSArray *)umk_parameterPairsWithKey:(NSString *)key
+- (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key
 {
-    NSMutableArray *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
+    NSMutableArray<UMKParameterPair *> *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
     NSString *nestedKey = [NSString stringWithFormat:@"%@[]", key];
     for (id value in self) {
         [pairs addObjectsFromArray:[value umk_parameterPairsWithKey:nestedKey]];
@@ -90,7 +90,7 @@
 
 - (BOOL)umk_isValidURLEncodedParameterObject
 {
-    if ([self count] == 0) {
+    if (self.count == 0) {
         return NO;
     }
     
@@ -111,7 +111,7 @@
 @implementation NSDictionary (UMKURLEncoding)
 
 
-+ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string
++ (NSDictionary<NSString *, id> * _Nullable)umk_dictionaryWithURLEncodedParameterString:(NSString *)string
 {
     NSParameterAssert(string);
     UMKURLEncodedParameterStringParser *parser = [[UMKURLEncodedParameterStringParser alloc] initWithString:string];
@@ -119,7 +119,7 @@
 }
 
 
-+ (instancetype)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding
++ (NSDictionary<NSString *, id> * _Nullable)umk_dictionaryWithURLEncodedParameterString:(NSString *)string encoding:(NSStringEncoding)encoding
 {
     return [self umk_dictionaryWithURLEncodedParameterString:string];
 }
@@ -128,7 +128,7 @@
 - (BOOL)umk_isValidURLEncodedParameterObject
 {
     for (id key in self) {
-        id value = [self objectForKey:key];
+        id value = self[key];
         if (![key isKindOfClass:[NSString class]] || ![value umk_isValidURLEncodedParameterObject]) {
             return NO;
         }
@@ -146,14 +146,8 @@
 
 - (NSString *)umk_URLEncodedParameterString
 {
-    NSArray *pairs = [self umk_parameterPairsWithKey:nil];
-    NSMutableArray *pairStrings = [[NSMutableArray alloc] initWithCapacity:pairs.count];
-
-    for (UMKParameterPair *pair in pairs) {
-        [pairStrings addObject:[pair URLEncodedStringValue]];
-    }
-
-    return [pairStrings componentsJoinedByString:@"&"];
+    NSArray<UMKParameterPair *> *pairs = [self umk_parameterPairsWithKey:nil];
+    return [[pairs valueForKey:NSStringFromSelector(@selector(URLEncodedStringValue))] componentsJoinedByString:@"&"];
 }
 
 
@@ -163,13 +157,13 @@
 }
 
 
-- (NSArray *)umk_parameterPairsWithKey:(NSString *)key
+- (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key
 {
     NSArray *sortedNestedKeys = [[self allKeys] sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
         return [[obj1 description] caseInsensitiveCompare:[obj2 description]];
     }];
 
-    NSMutableArray *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
+    NSMutableArray<UMKParameterPair *> *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
     for (id nestedKey in sortedNestedKeys) {
         NSString *parameterPairKey = key ? [NSString stringWithFormat:@"%@[%@]", key, nestedKey] : nestedKey;
         id value = self[nestedKey];
@@ -186,9 +180,9 @@
 
 @implementation NSSet (UMKURLEncoding)
 
-- (NSArray *)umk_parameterPairsWithKey:(NSString *)key
+- (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key
 {
-    NSMutableArray *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
+    NSMutableArray<UMKParameterPair *> *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
     for (id element in self) {
         [pairs addObjectsFromArray:[element umk_parameterPairsWithKey:key]];
     }
@@ -199,7 +193,7 @@
 
 - (BOOL)umk_isValidURLEncodedParameterObject
 {
-    if ([self count] < 2) {
+    if (self.count < 2) {
         return NO;
     }
     

--- a/URLMock/Categories/NSException+UMKSubclassResponsibility.h
+++ b/URLMock/Categories/NSException+UMKSubclassResponsibility.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  The UMKSubclassResponsibility category of NSException provides a convenience factory method for creating
  exceptions when implementing a given method is a subclass's responsibility.
@@ -43,3 +45,5 @@
 + (instancetype)umk_subclassResponsibilityExceptionWithReceiver:(id)receiver selector:(SEL)selector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Categories/NSURL+UMKQueryParameters.h
+++ b/URLMock/Categories/NSURL+UMKQueryParameters.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  The UMKQueryParameters category of NSURL adds methods to create and initialize NSURLs with 
  URL-encoded query parameters.
@@ -37,27 +39,30 @@
  @abstract Returns a newly initialized NSURL object with the specified URL string and query parameters.
  @discussion This method expects URLString to contain only characters that are allowed in a properly
      formed URL. All other characters must be properly percent escaped. Any percent-escaped characters
-     are interpreted using UTF-8 encoding. May not be nil.
+     are interpreted using UTF-8 encoding.
  @param URLString The URL string with which to initialize the NSURL object. May not be nil. Must conform
      to RFC 2396.
  @param parameters The parameters object to use to build the NSURL object's query string.
  @result A newly initialized NSURL object
  */
-- (instancetype)umk_initWithString:(NSString *)URLString parameters:(NSDictionary *)parameters;
+- (_Nullable instancetype)umk_initWithString:(NSString *)URLString
+                                  parameters:(NSDictionary * _Nullable)parameters NS_SWIFT_UNAVAILABLE("use init(string:parameters:) instead");
 
 /*!
  @abstract Returns a newly initialized NSURL object with the specified base URL, relative
      string, and query parameters.
  @discussion This method expects URLString to contain only characters that are allowed in a properly
      formed URL. All other characters must be properly percent escaped. Any percent-escaped characters
-     are interpreted using UTF-8 encoding. May not be nil.
+     are interpreted using UTF-8 encoding.
  @param URLString The URL string with which to initialize the NSURL object. May not be nil. Must conform
      to RFC 2396.
  @param parameters The parameters object to use to build the NSURL object's query string.
  @param baseURL The base URL for the NSURL object.
  @result A newly initialized NSURL object
  */
-- (instancetype)umk_initWithString:(NSString *)URLString parameters:(NSDictionary *)parameters relativeToURL:(NSURL *)baseURL;
+- (_Nullable instancetype)umk_initWithString:(NSString *)URLString
+                                  parameters:(NSDictionary * _Nullable)parameters
+                               relativeToURL:(NSURL * _Nullable)baseURL NS_SWIFT_UNAVAILABLE("use init(string:parameters:relativeToURL:) instead");
 
 /*!
  @abstract Creates and returns an NSURL object initialized with the specified URL string and query parameters.
@@ -69,7 +74,8 @@
  @param parameters The parameters object to use to build the NSURL object's query string.
  @result An NSURL object
  */
-+ (instancetype)umk_URLWithString:(NSString *)URLString parameters:(NSDictionary *)parameters;
++ (_Nullable instancetype)umk_URLWithString:(NSString *)URLString
+                                 parameters:(NSDictionary * _Nullable)parameters NS_SWIFT_NAME(init(string:parameters:));
 
 /*!
  @abstract Creates and returns an NSURL object initialized with the specified base URL, relative
@@ -83,6 +89,10 @@
  @param baseURL The base URL for the NSURL object.
  @result An NSURL object
  */
-+ (instancetype)umk_URLWithString:(NSString *)URLString parameters:(NSDictionary *)parameters relativeToURL:(NSURL *)baseURL;
++ (_Nullable instancetype)umk_URLWithString:(NSString *)URLString
+                                 parameters:(NSDictionary * _Nullable)parameters
+                              relativeToURL:(NSURL * _Nullable)baseURL NS_SWIFT_NAME(init(string:parameters:relativeToURL:));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Categories/NSURLRequest+UMKHTTPConvenienceMethods.h
+++ b/URLMock/Categories/NSURLRequest+UMKHTTPConvenienceMethods.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  The UMKHTTPConvenienceMethods category on NSURLRequest adds methods to NSURLRequests to make it easier to
  get the request’s HTTP body in numerous forms and compare its HTTP headers to those in a specified dictionary.
@@ -42,7 +44,7 @@
      Note that if the receiver has an HTTP body stream, this method may only be invoked once per URL request.
      Subsequent invocations will return nil.
  */
-- (NSData *)umk_HTTPBodyData;
+- (NSData * _Nullable)umk_HTTPBodyData;
 
 /*!
  @abstract Returns the receiver's HTTP body as a JSON object.
@@ -50,7 +52,7 @@
      this method may only be invoked once per URL request. Subsequent invocations will return nil.
  @result The receiver's body as a JSON object, or nil if the receiver's body does not contain valid JSON data.
  */
-- (id)umk_JSONObjectFromHTTPBody;
+- (_Nullable id)umk_JSONObjectFromHTTPBody;
 
 /*!
  @abstract Returns a dictionary representation of the receiver's HTTP body intepreted as URL-encoded WWW form parameters.
@@ -59,7 +61,7 @@
  @result A dictionary of the receiver's body as form parameters. Keys are strings. Values are either strings or the
      NSNull instance.
  */
-- (NSDictionary *)umk_parametersFromURLEncodedHTTPBody;
+- (NSDictionary<NSString *, id> * _Nullable)umk_parametersFromURLEncodedHTTPBody;
 
 /*!
  @abstract Returns the receiver's HTTP body as a UTF-8-encoded string.
@@ -67,7 +69,7 @@
      this method may only be invoked once per URL request. Subsequent invocations will return nil.
  @result The receiver's HTTP body as a UTF-8 encoded string.
  */
-- (NSString *)umk_stringFromHTTPBody;
+- (NSString * _Nullable)umk_stringFromHTTPBody;
 
 /*!
  @abstract Returns the receiver's HTTP body as a string in the specified encoding.
@@ -76,15 +78,17 @@
  @param encoding The encoding to use to convert the string to a data object.
  @result The receiver's HTTP body as a string in the specified encoding.
  */
-- (NSString *)umk_stringFromHTTPBodyWithEncoding:(NSStringEncoding)encoding;
+- (NSString * _Nullable)umk_stringFromHTTPBodyWithEncoding:(NSStringEncoding)encoding;
 
 /*!
  @abstract Returns whether the specified headers are equal to the receiver's HTTP headers.
  @discussion The receiver and the request have equal headers if they have the same number of them, their header fields
      are the same (case-insensitively), and the header values for those fields identical.
  @param headers The HTTP headers being compared to the receiver's.
- @result Whether the receiver's headers are equal to those specified. Returns NO if headers is nil.
+ @result Whether the receiver's headers are equal to those specified. 
  */
-- (BOOL)umk_HTTPHeadersAreEqualToHeaders:(NSDictionary *)headers;
+- (BOOL)umk_HTTPHeadersAreEqualToHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)headers;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Categories/NSURLRequest+UMKHTTPConvenienceMethods.m
+++ b/URLMock/Categories/NSURLRequest+UMKHTTPConvenienceMethods.m
@@ -69,7 +69,7 @@
 }
 
 
-- (NSDictionary *)umk_parametersFromURLEncodedHTTPBody
+- (NSDictionary<NSString *, id> * _Nullable)umk_parametersFromURLEncodedHTTPBody
 {
     NSString *bodyString = [self umk_stringFromHTTPBody];
     return bodyString ? [NSDictionary umk_dictionaryWithURLEncodedParameterString:bodyString] : nil;
@@ -89,7 +89,7 @@
 }
 
 
-- (BOOL)umk_HTTPHeadersAreEqualToHeaders:(NSDictionary *)headers
+- (BOOL)umk_HTTPHeadersAreEqualToHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)headers
 {
     if (headers.count != self.allHTTPHeaderFields.count) {
         return NO;

--- a/URLMock/Mock Messages/UMKMockHTTPMessage.h
+++ b/URLMock/Mock Messages/UMKMockHTTPMessage.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark Constants
 
 /*! The HTTP header field for the Accepts header, i.e., "Accepts". */
@@ -62,14 +64,14 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
  */
 @interface UMKMockHTTPMessage : NSObject {
 @protected
-    NSMapTable *_headers;
+    NSMapTable<NSString *, NSString *> *_headers;
 }
 
 /*! The instance's body. */
-@property (nonatomic, copy) NSData *body;
+@property (nonatomic, copy, nullable) NSData *body;
 
 /*! The instance's HTTP headers. */
-@property (nonatomic, copy) NSDictionary *headers;
+@property (nonatomic, copy, null_resettable) NSDictionary<NSString *, NSString *> *headers;
 
 
 /*! @methodgroup HTTP headers */
@@ -79,7 +81,7 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
  @param field The header field whose value should be retrieved.
  @result The value for the specified header field or nil if the receiver has no such header.
  */
-- (NSString *)valueForHeaderField:(NSString *)field;
+- (NSString * _Nullable)valueForHeaderField:(NSString *)field;
 
 /*!
  @abstract Sets the receiver's header value for the specified header field.
@@ -111,7 +113,7 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
  @abstract Returns the receiver's body as a JSON object.
  @result The receiver's body as a JSON object, or nil if the receiver's body does not contain valid JSON data.
  */
-- (id)JSONObjectFromBody;
+- (_Nullable id)JSONObjectFromBody;
 
 /*!
  @abstract Sets the receiver's body to a serialized form of the specified JSON object.
@@ -127,7 +129,7 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
  @result A dictionary of the receiver's body as form parameters. Keys are strings. Values are either strings or the
      NSNull instance.
  */
-- (NSDictionary *)parametersFromURLEncodedBody;
+- (NSDictionary<NSString *, id> * _Nullable)parametersFromURLEncodedBody;
 
 /*!
  @abstract Sets the receiver's body as a WWW Form URL-encoded representation of the specified dictionary.
@@ -137,13 +139,13 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
      Values may be any object type; the value used in the receiver's body will be the result of invoking -description
      on the value.
  */
-- (void)setBodyByURLEncodingParameters:(NSDictionary *)parameters;
+- (void)setBodyByURLEncodingParameters:(NSDictionary<NSString *, id> *)parameters;
 
 /*!
  @abstract Returns the receiver's body as a UTF-8-encoded string.
  @result The receiver's body as a UTF-8 encoded string.
  */
-- (NSString *)stringFromBody;
+- (NSString * _Nullable)stringFromBody;
 
 /*!
  @abstract Sets the receiver's body as a UTF-8 encoded version of the specified string.
@@ -156,7 +158,7 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
  @param encoding The encoding to use to convert the string to a data object.
  @result The receiver's body as a string in the specified encoding.
  */
-- (NSString *)stringFromBodyWithEncoding:(NSStringEncoding)encoding;
+- (NSString * _Nullable)stringFromBodyWithEncoding:(NSStringEncoding)encoding;
 
 /*!
  @abstract Sets the receiver's body to the specified string in the specified encoding.
@@ -166,3 +168,5 @@ extern NSString *const kUMKMockHTTPMessageUTF8WWWFormURLEncodedContentTypeHeader
 - (void)setBodyWithString:(NSString *)string encoding:(NSStringEncoding)encoding;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Mock Messages/UMKMockHTTPMessage.m
+++ b/URLMock/Mock Messages/UMKMockHTTPMessage.m
@@ -82,13 +82,13 @@ static BOOL UMKCaseInsensitiveStringIsEqualFunction(const void *item1, const voi
 
 #pragma mark - Headers
 
-- (NSDictionary *)headers
+- (NSDictionary<NSString *, NSString *> *)headers
 {
     return [_headers dictionaryRepresentation];
 }
 
 
-- (void)setHeaders:(NSDictionary *)headers
+- (void)setHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)headers
 {
     [_headers removeAllObjects];
     [headers enumerateKeysAndObjectsUsingBlock:^(NSString *field, NSString *value, BOOL *stop) {
@@ -97,7 +97,7 @@ static BOOL UMKCaseInsensitiveStringIsEqualFunction(const void *item1, const voi
 }
 
 
-- (NSString *)valueForHeaderField:(NSString *)field
+- (NSString * _Nullable)valueForHeaderField:(NSString *)field
 {
     return [_headers objectForKey:field];
 }
@@ -133,7 +133,7 @@ static BOOL UMKCaseInsensitiveStringIsEqualFunction(const void *item1, const voi
 
 #pragma mark - Body
 
-- (id)JSONObjectFromBody
+- (_Nullable id)JSONObjectFromBody
 {
     return self.body ? [NSJSONSerialization JSONObjectWithData:self.body options:0 error:NULL] : nil;
 }
@@ -155,13 +155,13 @@ static BOOL UMKCaseInsensitiveStringIsEqualFunction(const void *item1, const voi
 }
 
 
-- (NSDictionary *)parametersFromURLEncodedBody
+- (NSDictionary<NSString *, id> * _Nullable)parametersFromURLEncodedBody
 {
     return self.body ? [NSDictionary umk_dictionaryWithURLEncodedParameterString:[self stringFromBody]] : nil;
 }
 
 
-- (void)setBodyByURLEncodingParameters:(NSDictionary *)parameters
+- (void)setBodyByURLEncodingParameters:(NSDictionary<NSString *, id> *)parameters
 {
     NSParameterAssert(parameters);
     

--- a/URLMock/Mock Messages/UMKMockHTTPRequest.h
+++ b/URLMock/Mock Messages/UMKMockHTTPRequest.h
@@ -28,6 +28,8 @@
 #import <URLMock/UMKMockURLProtocol.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark Constants
 
 /*! The DELETE HTTP method. */
@@ -79,6 +81,11 @@ extern NSString *const kUMKMockHTTPRequestPutMethod;
 @property (nonatomic, assign) BOOL checksBodyWhenMatching;
 
 /*!
+ @abstract ‑init is unavailable, because a request with a nil HTTPMethod or URL is nonsensical.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/*!
  @abstract Initializes a newly allocated instance with the specified HTTP method and URL.
  @discussion The returned object does not test header equivalence when matching.
  @param method The HTTP method for the new instance. May not be nil.
@@ -108,7 +115,10 @@ extern NSString *const kUMKMockHTTPRequestPutMethod;
  @param checksBody Whether the new instance should check body equality when determining if it matches a URL request.
  @result An initialized mock request instance.
  */
-- (instancetype)initWithHTTPMethod:(NSString *)method URL:(NSURL *)URL checksHeadersWhenMatching:(BOOL)checksHeaders checksBodyWhenMatching:(BOOL)checksBody;
+- (instancetype)initWithHTTPMethod:(NSString *)method
+                               URL:(NSURL *)URL
+         checksHeadersWhenMatching:(BOOL)checksHeaders
+            checksBodyWhenMatching:(BOOL)checksBody NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Creates and returns a new mock HTTP DELETE request to the specified URL.
@@ -159,7 +169,7 @@ extern NSString *const kUMKMockHTTPRequestPutMethod;
  @abstract Returns the default headers for new UMKMockHTTPRequest instances.
  @result The default headers for new UMKMockHTTPRequest instances or nil if no default has been set.
  */
-+ (NSDictionary *)defaultHeaders;
++ (NSDictionary<NSString *, NSString *> * _Nullable)defaultHeaders;
 
 /*!
  @abstract Sets the default headers for new UMKMockHTTPRequest instances.
@@ -168,7 +178,7 @@ extern NSString *const kUMKMockHTTPRequestPutMethod;
      process.
  @param defaultHeaders The headers that should be the default for all new UMKMockHTTPRequest instances.
  */
-+ (void)setDefaultHeaders:(NSDictionary *)defaultHeaders;
++ (void)setDefaultHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)defaultHeaders;
 
 
 /*! @methodgroup URL request matching */
@@ -184,3 +194,5 @@ extern NSString *const kUMKMockHTTPRequestPutMethod;
 - (BOOL)matchesURLRequest:(NSURLRequest *)request;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Mock Messages/UMKMockHTTPRequest.m
+++ b/URLMock/Mock Messages/UMKMockHTTPRequest.m
@@ -42,13 +42,15 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
 
 #pragma mark -
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  UMKMockHTTPRequestSettings store settings for the UMKMockHTTPRequest class.
  */
 @interface UMKMockHTTPRequestSettings : NSObject
 
 /*! The default headers for all new instances. Initially nil. */
-@property (copy) NSDictionary *defaultHeaders;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *defaultHeaders;
 
 @end
 
@@ -62,7 +64,7 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
 @interface UMKMockHTTPRequest ()
 
 /*! A canonical version of the instance's URL. */
-@property (readonly, strong, nonatomic) NSURL *canonicalURL;
+@property (nonatomic, strong, readonly) NSURL *canonicalURL;
 
 /*!
  @abstract Returns whether the receiver's body matches that of the specified URL request.
@@ -76,16 +78,12 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
 
 @end
 
+NS_ASSUME_NONNULL_END
+
 
 #pragma mark -
 
 @implementation UMKMockHTTPRequest
-
-- (instancetype)init
-{
-    return [self initWithHTTPMethod:nil URL:nil];
-}
-
 
 - (instancetype)initWithHTTPMethod:(NSString *)method URL:(NSURL *)URL
 {
@@ -112,8 +110,8 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
         _checksHeadersWhenMatching = checksHeaders;
         _checksBodyWhenMatching = checksBody;
         
-        if ([[self class] defaultHeaders]) {
-            self.headers = [[self class] defaultHeaders];
+        if ([self.class defaultHeaders]) {
+            self.headers = [self.class defaultHeaders];
         }
         
     }
@@ -182,13 +180,13 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
 }
 
 
-+ (NSDictionary *)defaultHeaders
++ (NSDictionary<NSString *, NSString *> * _Nullable)defaultHeaders
 {
     return self.settings.defaultHeaders;
 }
 
 
-+ (void)setDefaultHeaders:(NSDictionary *)defaultHeaders
++ (void)setDefaultHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)defaultHeaders
 {
     self.settings.defaultHeaders = defaultHeaders;
 }
@@ -233,7 +231,7 @@ NSString *const kUMKMockHTTPRequestPutMethod = @"PUT";
             return [[self JSONObjectFromBody] isEqual:[NSJSONSerialization JSONObjectWithData:body options:0 error:NULL]];
         } else if ([contentType rangeOfString:kUMKMockHTTPMessageWWWFormURLEncodedContentTypeHeaderValue].location != NSNotFound) {
             NSString *requestBodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
-            NSDictionary *bodyParameters = [NSDictionary umk_dictionaryWithURLEncodedParameterString:requestBodyString];
+            NSDictionary<NSString *, id> *bodyParameters = [NSDictionary umk_dictionaryWithURLEncodedParameterString:requestBodyString];
             return [[self parametersFromURLEncodedBody] isEqualToDictionary:bodyParameters];
         }
     }

--- a/URLMock/Mock Messages/UMKMockHTTPResponder.h
+++ b/URLMock/Mock Messages/UMKMockHTTPResponder.h
@@ -28,6 +28,8 @@
 #import <URLMock/UMKMockURLProtocol.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  UMKMockHTTPResponder objects respond to mock HTTP URL requests. Instances can be created to respond with
  an NSError, an HTTP response, or even an HTTP response with its body broken into multiple chunks that are
@@ -75,7 +77,7 @@
  @param headers The HTTP headers to respond with.
  @result A newly initialized UMKMockHTTPResponseResponder with the specified status code and headers.
  */
-+ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode headers:(NSDictionary *)headers;
++ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode headers:(NSDictionary<NSString *, NSString *> * _Nullable)headers;
 
 /*!
  @abstract Returns a new UMKMockHTTPResponder instance that responds by sending an HTTP response with the
@@ -86,7 +88,7 @@
  @param body The HTTP body to respond with.
  @result A newly initialized UMKMockHTTPResponseResponder with the specified status code and body.
  */
-+ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode body:(NSData *)body;
++ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode body:(NSData * _Nullable)body;
 
 /*!
  @abstract Returns a new UMKMockHTTPResponder instance that responds by sending an HTTP response with the
@@ -98,7 +100,9 @@
  @param body The HTTP body to respond with.
  @result A newly initialized UMKMockHTTPResponseResponder with the specified status code, headers, and body.
  */
-+ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode headers:(NSDictionary *)headers body:(NSData *)body;
++ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode
+                                        headers:(NSDictionary<NSString *, NSString *> * _Nullable)headers
+                                           body:(NSData * _Nullable)body;
 
 /*!
  @abstract Returns a new UMKMockHTTPResponder instance with the specified status code, headers, body, chunk
@@ -112,7 +116,12 @@
      is only used if chunks is more than 1. Must be non-negative.
  @result A newly initialized UMKMockHTTPResponder with the specified parameters.
  */
-+ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode headers:(NSDictionary *)headers body:(NSData *)body
-                                 chunkCountHint:(NSUInteger)hint delayBetweenChunks:(NSTimeInterval)delay;
++ (instancetype)mockHTTPResponderWithStatusCode:(NSInteger)statusCode
+                                        headers:(NSDictionary<NSString *, NSString *> * _Nullable)headers
+                                           body:(NSData * _Nullable)body
+                                 chunkCountHint:(NSUInteger)hint
+                             delayBetweenChunks:(NSTimeInterval)delay;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Mock URL Protocol/UMKMockURLProtocol+UMKHTTPConvenienceMethods.h
+++ b/URLMock/Mock URL Protocol/UMKMockURLProtocol+UMKHTTPConvenienceMethods.h
@@ -29,6 +29,9 @@
 
 @class UMKMockHTTPRequest;
 
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UMKMockURLProtocol (UMKHTTPConvenienceMethods)
 
 /*! @methodgroup Mock Requests with JSON Bodies with Error Responders */
@@ -43,8 +46,10 @@
  @param error The error that the mock responder responds with. May not be nil.
  @result The newly created mock HTTP request. Its responder is set to the new mock error responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPRequestWithMethod:(NSString *)method URL:(NSURL *)URL
-                                            requestJSON:(id)requestJSON responseError:(NSError *)error;
++ (UMKMockHTTPRequest *)expectMockHTTPRequestWithMethod:(NSString *)method
+                                                    URL:(NSURL *)URL
+                                            requestJSON:(_Nullable id)requestJSON
+                                          responseError:(NSError *)error;
 
 /*!
  @abstract Creates and expects a new mock HTTP GET request that responds with an error.
@@ -65,7 +70,7 @@
  @param error The error that the mock responder responds with. May not be nil.
  @result The newly created mock HTTP PATCH request. Its responder is set to the new mock error responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPatchRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON responseError:(NSError *)error;
++ (UMKMockHTTPRequest *)expectMockHTTPPatchRequestWithURL:(NSURL *)URL requestJSON:(_Nullable id)requestJSON responseError:(NSError *)error;
 
 /*!
  @abstract Creates and expects a new mock HTTP POST request that responds with an error.
@@ -76,7 +81,7 @@
  @param error The error that the mock responder responds with. May not be nil.
  @result The newly created mock HTTP POST request. Its responder is set to the new mock error responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPostRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON responseError:(NSError *)error;
++ (UMKMockHTTPRequest *)expectMockHTTPPostRequestWithURL:(NSURL *)URL requestJSON:(_Nullable id)requestJSON responseError:(NSError *)error;
 
 /*!
  @abstract Creates and expects a new mock HTTP PUT request that responds with an error.
@@ -87,7 +92,7 @@
  @param error The error that the mock responder responds with. May not be nil.
  @result The newly created mock HTTP PUT request. Its responder is set to the new mock error responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPutRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON responseError:(NSError *)error;
++ (UMKMockHTTPRequest *)expectMockHTTPPutRequestWithURL:(NSURL *)URL requestJSON:(_Nullable id)requestJSON responseError:(NSError *)error;
 
 
 /*! @methodgroup Mock Requests and Responders with JSON Bodies */
@@ -103,8 +108,11 @@
  @param responseJSON A JSON object to use as the mock HTTP response body.
  @result The newly created mock HTTP request. Its responder is set to the new mock JSON body responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPRequestWithMethod:(NSString *)method URL:(NSURL *)URL requestJSON:(id)requestJSON
-                                     responseStatusCode:(NSInteger)statusCode responseJSON:(id)responseJSON;
++ (UMKMockHTTPRequest *)expectMockHTTPRequestWithMethod:(NSString *)method
+                                                    URL:(NSURL *)URL
+                                            requestJSON:(_Nullable id)requestJSON
+                                     responseStatusCode:(NSInteger)statusCode
+                                           responseJSON:(_Nullable id)responseJSON;
 
 /*!
  @abstract Creates and expects a new mock HTTP GET request that responds with a JSON object.
@@ -115,7 +123,9 @@
  @param responseJSON A JSON object to use as the mock HTTP response body.
  @result The newly created mock HTTP GET request. Its responder is set to the new mock JSON body responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPGetRequestWithURL:(NSURL *)URL responseStatusCode:(NSInteger)statusCode responseJSON:(id)responseJSON;
++ (UMKMockHTTPRequest *)expectMockHTTPGetRequestWithURL:(NSURL *)URL
+                                     responseStatusCode:(NSInteger)statusCode
+                                           responseJSON:(_Nullable id)responseJSON;
 
 /*!
  @abstract Creates and expects a new mock HTTP PATCH request that responds with a JSON object.
@@ -127,8 +137,10 @@
  @param responseJSON A JSON object to use as the mock HTTP response body.
  @result The newly created mock HTTP PATCH request. Its responder is set to the new mock JSON body responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPatchRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON
-                                       responseStatusCode:(NSInteger)statusCode responseJSON:(id)responseJSON;
++ (UMKMockHTTPRequest *)expectMockHTTPPatchRequestWithURL:(NSURL *)URL
+                                              requestJSON:(_Nullable id)requestJSON
+                                       responseStatusCode:(NSInteger)statusCode
+                                             responseJSON:(_Nullable id)responseJSON;
 
 /*!
  @abstract Creates and expects a new mock HTTP POST request that responds with a JSON object.
@@ -140,8 +152,10 @@
  @param responseJSON A JSON object to use as the mock HTTP response body.
  @result The newly created mock HTTP POST request. Its responder is set to the new mock JSON body responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPostRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON
-                                      responseStatusCode:(NSInteger)statusCode responseJSON:(id)responseJSON;
++ (UMKMockHTTPRequest *)expectMockHTTPPostRequestWithURL:(NSURL *)URL
+                                             requestJSON:(_Nullable id)requestJSON
+                                      responseStatusCode:(NSInteger)statusCode
+                                            responseJSON:(_Nullable id)responseJSON;
 
 /*!
  @abstract Creates and expects a new mock HTTP PUT request that responds with a JSON object.
@@ -153,7 +167,11 @@
  @param responseJSON A JSON object to use as the mock HTTP response body.
  @result The newly created mock HTTP PUT request. Its responder is set to the new mock JSON body responder.
  */
-+ (UMKMockHTTPRequest *)expectMockHTTPPutRequestWithURL:(NSURL *)URL requestJSON:(id)requestJSON
-                                     responseStatusCode:(NSInteger)statusCode responseJSON:(id)responseJSON;
++ (UMKMockHTTPRequest *)expectMockHTTPPutRequestWithURL:(NSURL *)URL
+                                            requestJSON:(_Nullable id)requestJSON
+                                     responseStatusCode:(NSInteger)statusCode
+                                           responseJSON:(_Nullable id)responseJSON;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Mock URL Protocol/UMKMockURLProtocol.h
+++ b/URLMock/Mock URL Protocol/UMKMockURLProtocol.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! The error domain for the URLMock framework. */
 extern NSString *const kUMKErrorDomain;
 
@@ -79,7 +81,7 @@ typedef NS_ENUM(NSInteger, UMKErrorCode) {
  @abstract Returns all expected mock requests.
  @result An array of all mock requests that are currently expected.
  */
-+ (NSArray *)expectedMockRequests;
++ (NSArray<id<UMKMockURLRequest>> *)expectedMockRequests;
 
 /*!
  @abstract Adds the specified mock request to the protocol's set of expected mock requests.
@@ -130,13 +132,13 @@ typedef NS_ENUM(NSInteger, UMKErrorCode) {
  @throws NSInternalInconsistencyException if verification is not enabled.
  @result Whether verification succeeded.
  */
-+ (BOOL)verifyWithError:(NSError **)outError;
++ (BOOL)verifyWithError:(NSError * _Nullable * _Nullable)outError;
 
 /*!
  @abstract Returns an array of unexpected requests received since the last reset.
  @result An array of unexpected requests received since the receiver last received the +reset message.
  */
-+ (NSArray *)unexpectedRequests;
++ (NSArray<NSURLRequest *> *)unexpectedRequests;
 
 /*!
  @abstract Returns a dictionary of requests serviced since the last reset.
@@ -144,7 +146,7 @@ typedef NS_ENUM(NSInteger, UMKErrorCode) {
      requests that serviced them.
  @result A dictionary of requests serviced since the receiver last received the +reset message.
  */
-+ (NSDictionary *)servicedRequests;
++ (NSDictionary<NSURLRequest *, id<UMKMockURLRequest>> *)servicedRequests;
 
 
 /*! @methodgroup Getting canonical URLs */
@@ -223,3 +225,5 @@ typedef NS_ENUM(NSInteger, UMKErrorCode) {
 - (void)cancelResponse;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Pattern-Matching Mock Requests/UMKPatternMatchingMockRequest.h
+++ b/URLMock/Pattern-Matching Mock Requests/UMKPatternMatchingMockRequest.h
@@ -28,6 +28,8 @@
 #import <URLMock/UMKMockURLProtocol.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  @abstract Block type that return whether a mock request matches a request.
  @discussion This block type is used by pattern-matching mock requests to determine if the mock request matches
@@ -36,7 +38,7 @@
  @param parameters The URL pattern parameters that were parsed from the request’s URL
  @result Whether the request matches or not
  */
-typedef BOOL(^UMKParameterizedRequestMatchingBlock)(NSURLRequest *request, NSDictionary *parameters);
+typedef BOOL(^UMKParameterizedRequestMatchingBlock)(NSURLRequest *request, NSDictionary<NSString *, NSString *> *parameters);
 
 /*!
  @abstract Block type for generating a responder based on a request and the specified URL path parameters.
@@ -47,7 +49,7 @@ typedef BOOL(^UMKParameterizedRequestMatchingBlock)(NSURLRequest *request, NSDic
  @param parameters The URL pattern parameters that were parsed from the request’s URL
  @result A mock responder that responds to the specified request. May not be nil.
  */
-typedef id<UMKMockURLResponder>(^UMKParameterizedResponderGenerationBlock)(NSURLRequest *request, NSDictionary *parameters);
+typedef _Nonnull id<UMKMockURLResponder>(^UMKParameterizedResponderGenerationBlock)(NSURLRequest *request, NSDictionary<NSString *, NSString *> *parameters);
 
 
 /*!
@@ -81,14 +83,14 @@ typedef id<UMKMockURLResponder>(^UMKParameterizedResponderGenerationBlock)(NSURL
  @abstract The HTTP methods that the instance matches.
  @discussion If nil, the instance does not check a request’s HTTP method when matching.
  */
-@property (nonatomic, copy) NSSet *HTTPMethods;
+@property (nonatomic, copy, nullable) NSSet<NSString *> *HTTPMethods;
 
 /*! 
  @abstract The instance’s responder generation block.
  @discussion This block generates a mock responder for a given URL request and URL pattern parameters. It may not 
-     return nil. The return value of this block is what is returned by -responderForURLRequest:.
+     return nil. The return value of this block is what is returned by -responderForURLRequest:. 
  */
-@property (nonatomic, copy) UMKParameterizedResponderGenerationBlock responderGenerationBlock;
+@property (nonatomic, copy, nullable) UMKParameterizedResponderGenerationBlock responderGenerationBlock;
 
 /*!
  @abstract The instance’s request-matching block.
@@ -102,7 +104,12 @@ typedef id<UMKMockURLResponder>(^UMKParameterizedResponderGenerationBlock)(NSURL
      most notably by other potential mock requests or in the body of your responder generation block. This is due to
      the nature of data streams. If the request has a non-nil HTTPBody, you may freely read the body in your block.
  */
-@property (nonatomic, copy) UMKParameterizedRequestMatchingBlock requestMatchingBlock;
+@property (nonatomic, copy, nullable) UMKParameterizedRequestMatchingBlock requestMatchingBlock;
+
+/*!
+ @abstract ‑init is unavailable, because a mock request with a nil URL pattern is nonsensical.
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
 /*!
  @abstract Initializes a newly allocated instance with the specified URL pattern and responder generation block.
@@ -111,6 +118,8 @@ typedef id<UMKMockURLResponder>(^UMKParameterizedResponderGenerationBlock)(NSURL
  @param URLPattern The URL pattern for the new instance. May not be nil.
  @result An initialized pattern-matching mock request instance.
  */
-- (instancetype)initWithURLPattern:(NSString *)URLPattern;
+- (instancetype)initWithURLPattern:(NSString *)URLPattern NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Pattern-Matching Mock Requests/UMKPatternMatchingMockRequest.m
+++ b/URLMock/Pattern-Matching Mock Requests/UMKPatternMatchingMockRequest.m
@@ -41,12 +41,6 @@
 
 @implementation UMKPatternMatchingMockRequest
 
-- (instancetype)init
-{
-    return [self initWithURLPattern:nil];
-}
-
-
 - (instancetype)initWithURLPattern:(NSString *)URLPattern
 {
     NSParameterAssert(URLPattern);
@@ -61,7 +55,7 @@
 }
 
 
-- (void)setHTTPMethods:(NSSet *)HTTPMethods
+- (void)setHTTPMethods:(NSSet<NSString *> *)HTTPMethods
 {
     _HTTPMethods = [HTTPMethods valueForKey:@"uppercaseString"];
 }
@@ -83,9 +77,12 @@
     NSString *URLString = [self canonicalURLStringExcludingQueryForURL:request.URL];
     if (![self.pattern stringMatches:URLString]) {
         return NO;
+    } else if (!self.requestMatchingBlock) {
+        return YES;
     }
 
-    return self.requestMatchingBlock ? self.requestMatchingBlock(request, [self.pattern parameterDictionaryFromSourceString:URLString]) : YES;
+    NSDictionary<NSString *, NSString *> *parameters = [self.pattern parameterDictionaryFromSourceString:URLString];
+    return self.requestMatchingBlock(request, parameters ? parameters : nil);
 }
 
 
@@ -96,7 +93,8 @@
     }
 
     NSString *URLString = [self canonicalURLStringExcludingQueryForURL:request.URL];
-    return self.responderGenerationBlock(request, [self.pattern parameterDictionaryFromSourceString:URLString]);
+    NSDictionary<NSString *, NSString *> *parameters = [self.pattern parameterDictionaryFromSourceString:URLString];
+    return self.responderGenerationBlock(request, parameters ? parameters : nil);
 }
 
 

--- a/URLMock/Utilities/UMKErrorUtilities.h
+++ b/URLMock/Utilities/UMKErrorUtilities.h
@@ -34,6 +34,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  @abstract Returns an NSString representation of the selector.
  @discussion This simply returns the result of NSStringFromSelector(selector), prefixed with a '+' if receiver is 
@@ -73,3 +75,5 @@ extern NSString *UMKAssertionString(id receiver, SEL selector, NSString *format,
  @result An NSString formatted suitable for use as an exception message.
  */
 extern NSString *UMKExceptionString(id receiver, SEL selector, NSString *format, ...) NS_FORMAT_FUNCTION(3, 4);
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Utilities/UMKMessageCountingProxy.h
+++ b/URLMock/Utilities/UMKMessageCountingProxy.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  Instances of UMKMessageCountingProxy count how many times their associated objects have received messages.
  This is useful when testing that APIs are actually being invoked.
@@ -76,3 +78,5 @@
 - (NSUInteger)receivedMessageCountForSelector:(SEL)selector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Utilities/UMKMessageCountingProxy.m
+++ b/URLMock/Utilities/UMKMessageCountingProxy.m
@@ -29,7 +29,7 @@
 
 @interface UMKMessageCountingProxy ()
 
-@property (nonatomic, strong) NSMutableDictionary *receivedMessageCounts;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *receivedMessageCounts;
 
 @end
 

--- a/URLMock/Utilities/UMKParameterPair.h
+++ b/URLMock/Utilities/UMKParameterPair.h
@@ -28,6 +28,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  UMKParameterPair objects store a key-value pair for use with URL encoding/decoding APIs in URLMock.
  @note The basic design and some of the code here is adapted or borrowed from AFNetworking.
@@ -35,10 +37,13 @@
 @interface UMKParameterPair : NSObject
 
 /*! The instance's key. */
-@property (nonatomic, strong) NSString *key;
+@property (nonatomic, copy) NSString *key;
 
 /*! The instance's value. */
-@property (nonatomic, strong) id value;
+@property (nonatomic, strong, nullable) id value;
+
+
+- (instancetype)init NS_UNAVAILABLE;
 
 /*!
  @abstract Returns a newly initialized UMKParameterPair instance with the specfied key and value.
@@ -46,7 +51,7 @@
  @param value The value for the new pair object.
  @result A newly initialized UMKParameterPair with the specified key and value.
  */
-- (instancetype)initWithKey:(NSString *)key value:(id)value;
+- (instancetype)initWithKey:(NSString *)key value:(_Nullable id)value NS_DESIGNATED_INITIALIZER;
 
 /*! 
  @abstract Returns a URL encoded string representation of the receiver.
@@ -67,3 +72,5 @@
 - (NSString *)URLEncodedStringValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Utilities/UMKParameterPair.m
+++ b/URLMock/Utilities/UMKParameterPair.m
@@ -34,9 +34,11 @@
 
 - (instancetype)initWithKey:(NSString *)key value:(id)value
 {
+    NSParameterAssert(key);
+
     self = [super init];
     if (self) {
-        _key = key;
+        _key = [key copy];
         _value = value;
     }
     
@@ -57,7 +59,8 @@
 
     NSString *stringValue = [self URLEncodedString:self.key allowedCharacters:kUMKKeyAllowedCharacters];
     if (self.value && self.value != [NSNull null]) {
-        stringValue = [stringValue stringByAppendingFormat:@"=%@", [self URLEncodedString:[self.value description] allowedCharacters:kUMKValueAllowedCharacters]];
+        stringValue = [stringValue stringByAppendingFormat:@"=%@", [self URLEncodedString:[self.value description]
+                                                                        allowedCharacters:kUMKValueAllowedCharacters]];
     }
     
     return stringValue;

--- a/URLMock/Utilities/UMKTestUtilities.h
+++ b/URLMock/Utilities/UMKTestUtilities.h
@@ -33,6 +33,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @functiongroup Block-generated collections */
 
 /*!
@@ -54,7 +56,7 @@ extern NSArray *UMKGeneratedArrayWithElementCount(NSUInteger count, id (^element
      will not terminate. For example, the following invocation will never return, as (random() % 4) can only return
      four values, but the requested element count is 5.
  
-         NSDictionary *randomStrings = UMKGeneratedDictionaryWithElementCount(5, id^{
+         NSDictionary<NSNumber *, NSString *> *randomStrings = UMKGeneratedDictionaryWithElementCount(5, id^{
              return @(random() % 4);
          }, id^(id key) {
              return UMKRandomUnicodeStringWithLength([key unsignedIntegerValue]);
@@ -78,7 +80,7 @@ extern NSDictionary *UMKGeneratedDictionaryWithElementCount(NSUInteger count, id
      will not terminate. For example, the following invocation will never return, as (random() % 4) can only return
      four values, but the requested element count is 5.
  
-         NSSet *randomNumbers = UMKGeneratedSetWithElementCount(5, id^{
+         NSSet<NSNumber *> *randomNumbers = UMKGeneratedSetWithElementCount(5, id^{
              return @(random() % 4);
          });
  @param count The number of elements in the newly created set.
@@ -168,7 +170,7 @@ extern NSNumber *UMKRandomUnsignedNumberInRange(NSRange range);
  @param count The number of entries in the newly created dictionary.
  @result A dictionary of random string key-value pairs.
  */
-extern NSDictionary *UMKRandomDictionaryOfStringsWithElementCount(NSUInteger count);
+extern NSDictionary<NSString *, NSString *> *UMKRandomDictionaryOfStringsWithElementCount(NSUInteger count);
 
 /*!
  @abstract Returns a new random dictionary that can be safely converted to and from a URL encoded parameter string.
@@ -180,7 +182,7 @@ extern NSDictionary *UMKRandomDictionaryOfStringsWithElementCount(NSUInteger cou
      object. Must be positive.
  @result A new random dictionary that can be safely converted to and from a URL encoded parameter string.
  */
-extern NSDictionary *UMKRandomURLEncodedParameterDictionary(NSUInteger maxNestingDepth, NSUInteger maxElementCountPerCollection);
+extern NSDictionary<NSString *, id> *UMKRandomURLEncodedParameterDictionary(NSUInteger maxNestingDepth, NSUInteger maxElementCountPerCollection);
 
 
 /*! @functiongroup Random JSON objects */
@@ -250,3 +252,5 @@ extern BOOL UMKWaitForCondition(NSTimeInterval timeoutInterval, BOOL (^condition
  */
 #define UMKAssertTrueBeforeTimeout(timeoutInterval, expression, format...) \
     XCTAssertTrue(UMKWaitForCondition((timeoutInterval), ^BOOL{ return (expression); }), ## format)
+
+NS_ASSUME_NONNULL_END

--- a/URLMock/Utilities/UMKTestUtilities.m
+++ b/URLMock/Utilities/UMKTestUtilities.m
@@ -255,7 +255,7 @@ NSDictionary *UMKGeneratedDictionaryWithElementCount(NSUInteger count, id (^keyG
 }
 
 
-NSDictionary *UMKRandomDictionaryOfStringsWithElementCount(NSUInteger count)
+NSDictionary<NSString *, NSString *> *UMKRandomDictionaryOfStringsWithElementCount(NSUInteger count)
 {
     return UMKGeneratedDictionaryWithElementCount(count, ^id{
         return UMKRandomAlphanumericString();
@@ -289,7 +289,7 @@ static id UMKRandomURLEncodedParameterArray(NSUInteger maxElementCountPerCollect
 }
 
 
-NSDictionary *UMKRandomURLEncodedParameterDictionary(NSUInteger maxNestingDepth, NSUInteger maxElementCountPerCollection)
+NSDictionary<NSString *, id> *UMKRandomURLEncodedParameterDictionary(NSUInteger maxNestingDepth, NSUInteger maxElementCountPerCollection)
 {
     NSCParameterAssert(maxNestingDepth > 0);
     NSCParameterAssert(maxElementCountPerCollection > 0);

--- a/URLMock/Utilities/UMKURLEncodedParameterStringParser.h
+++ b/URLMock/Utilities/UMKURLEncodedParameterStringParser.h
@@ -27,6 +27,8 @@
 #import <Foundation/Foundation.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  UMKURLEncodedParameterStringParser objects parse URL encoded parameter strings.
  
@@ -50,13 +52,17 @@
  */
 @property (nonatomic, assign, readonly) NSStringEncoding encoding DEPRECATED_ATTRIBUTE;
 
+/*!
+ @abstract ‑init is unavailable, because a string parser with a nil string is nonsensical.
+ */
+- (instancetype)init NS_UNAVAILABLE;
 
 /*!
  @abstract Initializes a new UMKURLEncodedParameterStringParser instance with the specified string.
  @param string The URL encoded parameter string to parse.
  @result A newly initialized UMKURLEncodedParameterStringParser.
  */
-- (instancetype)initWithString:(NSString *)string;
+- (instancetype)initWithString:(NSString *)string NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Deprecated. Use -initWithString: instead.
@@ -72,6 +78,8 @@
      keys, array values, and set values are strings. Sets never contain fewer than two items.
  @result The dictionary that results from parsing the receiver's string or nil if a parse error occurred.
  */
-- (NSDictionary *)parse;
+- (NSDictionary<NSString *, id> * _Nullable)parse;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
@jnjosh @dfowjtm @macdrevx This is my first attempt at Swift-ifying one of our frameworks. Given the number of changes, I’d really appreciate a thorough review. Nullability is particularly important, as I don’t want to guarantee non-null with interfaces that can in fact return null.