### PR TITLE
Allow +[UMKMockURLProtocol canonicalURLForURL:] to accept nil URLs

### DIFF
--- a/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
+++ b/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
@@ -95,8 +95,11 @@
     XCTAssertEqualObjects([UMKMockURLProtocol expectedMockRequests], @[], @"Mock request not removed");
 }
 
+
 - (void)testCanonicalURL
 {
+    XCTAssertNil([UMKMockURLProtocol canonicalURLForURL:nil], @"returns non-nil for nil URL");
+
     NSURL *testURL1 = [NSURL URLWithString:@"http://domain.com"];
     NSURL *canonicalURL1 = [UMKMockURLProtocol canonicalURLForURL:testURL1];
     XCTAssertEqualObjects(testURL1, canonicalURL1, @"canonicalURL should not mutate a URL without a query string");

--- a/URLMock/Mock URL Protocol/UMKMockURLProtocol.h
+++ b/URLMock/Mock URL Protocol/UMKMockURLProtocol.h
@@ -153,10 +153,10 @@ typedef NS_ENUM(NSInteger, UMKErrorCode) {
 
 /*!
  @abstract Returns the canonical version of the specified URL.
- @param URL The URL. May not be nil.
- @result The canonical version of the specified URL.
+ @param URL The URL.
+ @result The canonical version of the specified URL. Returns nil if the URL parameter is nil.
  */
-+ (NSURL *)canonicalURLForURL:(NSURL *)URL;
++ (NSURL * _Nullable)canonicalURLForURL:(NSURL * _Nullable)URL;
 
 @end
 

--- a/URLMock/Mock URL Protocol/UMKMockURLProtocol.m
+++ b/URLMock/Mock URL Protocol/UMKMockURLProtocol.m
@@ -477,8 +477,6 @@ NS_ASSUME_NONNULL_END
 
 + (NSURL *)canonicalURLForURL:(NSURL *)URL
 {
-    NSParameterAssert(URL);
-
     // Always use the absolute URL
     NSURL *canonicalURL = URL.absoluteURL;
     NSString *query = canonicalURL.query;


### PR DESCRIPTION
Fixes issue #45.

@Dfowj @jnjosh @macdrevx 